### PR TITLE
Add curl as a runtime dependency on alpine

### DIFF
--- a/0.15/alpine/Dockerfile
+++ b/0.15/alpine/Dockerfile
@@ -85,6 +85,7 @@ RUN adduser -S bitcoingold
 RUN apk --no-cache add \
   boost \
   boost-program_options \
+  curl \
   libevent \
   libressl \
   libzmq \


### PR DESCRIPTION
`nc` is not reliable enough for notification purposes so we're adding `curl` as a runtime dependency.